### PR TITLE
Remove default shell in Github workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Bash is already the default shell. We don't need to specify it explicitly.